### PR TITLE
fixes the Safari website crashes

### DIFF
--- a/prefs.xm
+++ b/prefs.xm
@@ -352,6 +352,10 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 
 	PLLog(@"Loading specifiers from PSListController's specifier's properties.");
 	NSMutableArray *&bundleControllers = MSHookIvar<NSMutableArray *>(self, "_bundleControllers");
+
+	// This code fixes the problem that the Safari website setting return crashes after entering the setting item.
+	if(!bundleControllers){return result;}
+	
 	NSString *title = nil;
 	NSString *specifierID = nil;
 	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);

--- a/prefs.xm
+++ b/prefs.xm
@@ -361,8 +361,8 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);
 	
 	// Fix the blank titles of the phone setting items [Mute Unknown Calls] and [Call Blocking and Identification] 
-	if(title.length > 0)
-		[self setTitle:title];
+	if(title)
+		[self setTitle:self.specifier.name];
 
 	if(specifierID)
 		[self setSpecifierID:specifierID];

--- a/prefs.xm
+++ b/prefs.xm
@@ -359,8 +359,9 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 	NSString *title = nil;
 	NSString *specifierID = nil;
 	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);
-
-	if(title)
+	
+	// Fix the blank titles of the phone setting items [Mute Unknown Calls] and [Call Blocking and Identification] 
+	if(title.length > 0)
 		[self setTitle:title];
 
 	if(specifierID)


### PR DESCRIPTION
This code fixes the problem that the Safari website setting return crashes after entering the setting item.